### PR TITLE
Use OptionSetType in README (Swift 2.0) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Or if you need to specify delay, animation options and/or animation curve:
 <td valign="top">
 <pre lang="Swift">
     UIView.animateWithDuration(2.0, delay: 2.0, 
-        options: .Repeat | .Autoreverse | .CurveEaseOut, 
+        options: [.Repeat, .Autoreverse, .CurveEaseOut], 
         animations: {
         self.view.layer.position.x += 200.0
 


### PR DESCRIPTION
The README example didn't work and stumped me for a little while until I realized that OptionSetType was [introduced in Swift 2.0](https://twitter.com/jasdev/status/689272113920868352). It's [in the sample code](https://github.com/icanzilb/EasyAnimation/blob/master/DemoApp/DemoApp/DemoLayerViewAnimationsViewController.swift#L20), I just caught it in the README 👍