### PR TITLE
Convenience methods

### DIFF
--- a/EasyAnimation.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/EasyAnimation.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/EasyAnimation/EAAnimationFuture.swift
+++ b/EasyAnimation/EAAnimationFuture.swift
@@ -133,6 +133,33 @@ public class EAAnimationFuture: Equatable, CustomStringConvertible {
         return nextDelayedAnimation!
     }
     
+    /**
+     Waits the specified duration.
+     
+     :param: duration The wait duration in seconds.
+     
+     :returns: The created request.
+     */
+    public func wait(_ duration: TimeInterval) -> EAAnimationFuture {
+        return animate(withDuration: 0, delay: duration, options: [], animations: {}, completion: nil)
+    }
+    
+    /**
+    Runs the code in the input block without animating.
+    
+    :param: block The block of code to run
+    
+    :returns: The created request.
+    */
+    @discardableResult
+    public func `do`(_ block: @escaping () -> Void) -> EAAnimationFuture {
+        return animate(withDuration: 0, animations: {}) { _ in
+            DispatchQueue.main.async {
+                block()
+            }
+        }
+    }
+    
     //MARK: - Animation control methods
     
     /**

--- a/EasyAnimation/EasyAnimation.swift
+++ b/EasyAnimation/EasyAnimation.swift
@@ -399,6 +399,19 @@ extension UIView {
     // MARK: chain animations
     
     /**
+     Creates and runs an animation which allows other animations to be chained to it and to each other.
+     
+     :param: duration The animation duration in seconds
+     :param: animations Animation closure
+     :param: completion Completion closure of type (Bool)->Void
+     
+     :returns: The created request.
+     */
+    public class func animateAndChain(withDuration duration: TimeInterval, animations: @escaping () -> Void) -> EAAnimationFuture {
+        return UIView.animateAndChain(withDuration: duration, delay: 0, options: [], animations: animations, completion: nil)
+    }
+    
+    /**
     Creates and runs an animation which allows other animations to be chained to it and to each other.
     
     :param: duration The animation duration in seconds


### PR DESCRIPTION
Added a few convenience methods.

* UIView.animateAndChain without the delay and options parameters, for brevity in situations where those parameters aren't needed.

* EAAnimationFuture.wait - waits a specified duration before moving on to the next part of the chain.

* EAAnimationFuture.do - executes the input block instantly without animating. 